### PR TITLE
feat: adicionar imagem Docker starman sem nginx

### DIFF
--- a/starman/Dockerfile
+++ b/starman/Dockerfile
@@ -1,0 +1,42 @@
+FROM ligero/ligerosmart:base
+
+# Extra perl modules
+RUN apt update \
+    && apt install -y \
+            build-essential \
+    && cpanm --sudo --quiet --notest Starman \
+    && cpanm --sudo --quiet --notest Devel::NYTProf \
+    && apt remove --purge -y \
+            build-essential \
+            libexpat1-dev \
+            libssl-dev \
+    && apt autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /root/.cpanm/
+
+# include supervisor config for starman
+COPY etc/supervisor/conf.d/starman.conf /etc/supervisor/conf.d/starman.conf
+
+# include files
+COPY var /var
+COPY app.psgi /
+COPY app-healthcheck.sh /app-healthcheck.sh
+
+# patches
+RUN /var/patches/apply.sh
+
+# post configuration
+RUN echo ". /etc/environment" > /opt/otrs/.profile
+    
+EXPOSE 80
+
+HEALTHCHECK --interval=20s --timeout=60s --retries=2 --start-period=10s CMD /app-healthcheck.sh
+
+# default env values for services
+ENV START_WEBSERVER=1 \
+    STARMAN_WORKERS=3 \
+    START_SCHEDULER=1 \
+    DEBUG_MODE=0 \
+    PLACK_ENV=deployment \
+    NYTPROF=start=no

--- a/starman/app-healthcheck.sh
+++ b/starman/app-healthcheck.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#set -x
+HEARTBEAT_FILE=/tmp/healthcheck_on
+HEARTBEAT_INTERVAL=${HEARTBEAT_INTERVAL:-4} # minutes
+
+if [ "$(pgrep -f httpserver.pl)" ]; then
+  exit 0
+fi
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+  touch $HEARTBEAT_FILE
+  exit 0
+fi
+
+if test -z `find "$HEARTBEAT_FILE" -mmin +$HEARTBEAT_INTERVAL`; then
+  # heartbeat ok
+  exit 0
+fi
+
+# WEBSERVER test - Starman direto na porta 80
+if [ "$START_WEBSERVER" == "1" ]; then
+    healthcheck_webserver_error=0
+    curl -m 50 -f -s http://127.0.0.1/otrs/index.pl?healthcheck -o /dev/null || healthcheck_webserver_error=1
+    if [ "$healthcheck_webserver_error" -eq 1 ]; then
+      echo "$0: webserver is not responding"
+      exit 1
+    fi
+fi;
+
+# SCHEDULER test
+if [ "$START_SCHEDULER" == "1" ]; then 
+  if [ -z "$(pgrep -f otrs.Daemon.pl)" ]; then
+    echo "$0: otrs.Daemon.pl is not running"
+    exit 1
+  fi
+fi;
+
+touch $HEARTBEAT_FILE
+
+
+# returns ok
+exit 0

--- a/starman/app.psgi
+++ b/starman/app.psgi
@@ -1,0 +1,134 @@
+#!/usr/bin/perl
+# --
+# Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
+# --
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.txt.
+# --
+
+# To profile single requests, install Devel::NYTProf and start this script as
+# PERL5OPT=-d:NYTProf NYTPROF='trace=1:start=no' plackup bin/cgi-bin/app.psgi
+# then append &NYTProf=mymarker to a request.
+# This creates a file called nytprof-mymarker.out, which you can process with
+# nytprofhtml -f nytprof-mymarker.out
+# Then point your browser at nytprof/index.html
+
+use strict;
+use warnings;
+
+# use ../../ as lib location
+use FindBin qw($Bin);
+BEGIN { $Bin = "/opt/otrs/bin/cgi-bin"; }
+use lib "$Bin/../..";
+use lib "$Bin/../../Kernel/cpan-lib";
+use lib "$Bin/../../Custom";
+
+## nofilter(TidyAll::Plugin::OTRS::Perl::SyntaxCheck)
+
+use CGI;
+use CGI::Emulate::PSGI;
+use Module::Refresh;
+use Plack::Builder;
+
+# Workaround: some parts of OTRS use exit to interrupt the control flow.
+#   This would kill the Plack server, so just use die instead.
+BEGIN {
+    *CORE::GLOBAL::exit = sub { die "exit called\n"; };
+}
+
+my $App = CGI::Emulate::PSGI->handler(
+    sub {
+
+        # Cleanup values from previous requests.
+        CGI::initialize_globals();
+
+        # Populate SCRIPT_NAME as OTRS needs it in some places.
+        $ENV{SCRIPT_NAME} = $ENV{PATH_INFO};
+
+        # set RemoteAddr behind proxy
+        if ( $ENV{HTTP_X_REAL_IP} ) {
+            $ENV{REMOTE_ADDR} = $ENV{HTTP_X_REAL_IP};
+        }
+
+        if ( $ENV{HTTP_X_FORWARDED_FOR} ) {
+            $ENV{REMOTE_ADDR} = $ENV{HTTP_X_FORWARDED_FOR};
+            #($ENV{REMOTE_ADDR}) = split /\s*,/, $ENV{HTTP_X_FORWARDED_FOR};
+        }
+
+        my ( $HandleScript ) = $ENV{PATH_INFO} =~ m{/([A-Za-z\-_]+\.pl)};    ## no critic
+ 
+        # Fallback to agent login if we could not determine handle...i
+        if ( !defined $HandleScript || !-e "$Bin/$HandleScript" ) {
+            $HandleScript = 'index.pl';                                   ## no critic
+        }
+
+        eval {
+
+            # Reload files in @INC that have changed since the last request.
+            Module::Refresh->refresh();
+        };
+        warn $@ if $@;
+
+        my $Profile;
+        my $ProfileSuffix;
+        if ( $ENV{NYTPROF} && $ENV{REQUEST_URI} =~ /NYTProf=([\w-]+)/ ) {
+            use Devel::NYTProf;
+            $Profile = 1;
+            $ProfileSuffix = $1;
+            DB::enable_profile("$Bin/../../var/log/nytprof-$1.out");
+        }
+
+        # Load the requested script
+        eval {
+            do "$Bin/$HandleScript";
+        };
+        if ( $@ && $@ ne "exit called\n" ) {
+            warn $@;
+        }
+
+        if ($Profile) {
+            DB::finish_profile();
+            system("HTMLProfileReportFor $ProfileSuffix");
+            #unlink "$Bin/../../var/log/nytprof-$1.out";
+        }
+    },
+);
+
+# Small helper function to determine the path to a static file
+my $StaticPath = sub {
+
+    # Everything in otrs-web/js or otrs-web/skins is a static file.
+    return 0 if $_ !~ m{-web/js/|-web/skins/};
+
+    # Return only the relative path.
+    $_ =~ s{^.*?-web/(js/.*|skins/.*)}{$1}smx;
+    return $_;
+};
+
+# Create a Static middleware to serve static files directly without invoking the OTRS
+#   application handler.
+builder {
+    # enable "StackTrace", force => $ENV{DEBUG_MODE};
+    if ($ENV{DEBUG_MODE} eq "1") {
+        enable "StackTrace", force => 1;
+    }
+    enable "Static",
+        path        => $StaticPath,
+        root        => "$Bin/../../var/httpd/htdocs",
+        pass_trough => 0;
+    enable "Plack::Middleware::ErrorDocument",
+        403 => '/var/www/html/403.html',
+        500 => '/var/www/html/50x.html',
+        502 => '/var/www/html/50x.html';
+    $App;
+}

--- a/starman/etc/supervisor/conf.d/starman.conf
+++ b/starman/etc/supervisor/conf.d/starman.conf
@@ -1,0 +1,10 @@
+[program:starman]
+environment=NYTPROF="start=no"
+command=starman --max-requests 2000 --port 80 --workers %(ENV_STARMAN_WORKERS)s /app.psgi
+user=otrs
+autostart=%(ENV_START_WEBSERVER)s
+autorestart=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0

--- a/starman/var/patches/StackTrace.patch
+++ b/starman/var/patches/StackTrace.patch
@@ -1,0 +1,11 @@
+--- /usr/local/share/perl/5.30.0/Plack/Middleware/StackTrace.pm.old     2024-05-02 18:54:27.398440236 -0300
++++ /usr/local/share/perl/5.30.0/Plack/Middleware/StackTrace.pm 2024-05-02 18:52:58.721375516 -0300
+@@ -22,7 +22,7 @@
+     local $SIG{__DIE__} = sub {
+         $trace = $StackTraceClass->new(
+             indent => 1, message => munge_error($_[0], [ caller ]),
+-            ignore_package => __PACKAGE__, no_refs => 1,
++            ignore_package => __PACKAGE__, no_refs => 0,
+         );
+         if (ref $_[0]) {
+             $ref_traces{refaddr($_[0])} ||= $trace;

--- a/starman/var/patches/apply.sh
+++ b/starman/var/patches/apply.sh
@@ -1,0 +1,1 @@
+sudo patch /usr/local/share/perl/5.30.0/Plack/Middleware/StackTrace.pm < /var/patches/StackTrace.patch


### PR DESCRIPTION
- Criar estrutura de diretórios starman/
- Implementar Dockerfile baseado em nginx mas sem servidor nginx
- Configurar Starman para escutar diretamente na porta 80
- Adaptar configuração supervisor para Starman apenas
- Adaptar healthcheck para testar Starman na porta 80
- Copiar app.psgi e patches do nginx
- Expor apenas porta 80